### PR TITLE
feat(weather-skill): update to v0.3.3

### DIFF
--- a/container/skills/weather/package.json
+++ b/container/skills/weather/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shrwnsan/weather-skill",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A platform-agnostic weather skill for AI agents (Bun/TypeScript runtime).",
   "type": "module",
   "engines": {

--- a/container/skills/weather/src/providers/open_meteo.ts
+++ b/container/skills/weather/src/providers/open_meteo.ts
@@ -162,11 +162,11 @@ export class OpenMeteoProvider implements IWeatherProvider {
 
     const sunrise =
       Array.isArray(daily.sunrise) && typeof daily.sunrise[0] === "string"
-        ? daily.sunrise[0]
+        ? formatTime(daily.sunrise[0])
         : undefined;
     const sunset =
       Array.isArray(daily.sunset) && typeof daily.sunset[0] === "string"
-        ? daily.sunset[0]
+        ? formatTime(daily.sunset[0])
         : undefined;
 
     return makeWeatherData({
@@ -247,8 +247,8 @@ export class OpenMeteoProvider implements IWeatherProvider {
           ? { precipitation_chance: precipChances[i] }
           : {}),
         ...(typeof uvIndices[i] === "number" ? { uv_index: uvIndices[i] } : {}),
-        ...(typeof sunrises[i] === "string" ? { sunrise: sunrises[i] } : {}),
-        ...(typeof sunsets[i] === "string" ? { sunset: sunsets[i] } : {}),
+        ...(typeof sunrises[i] === "string" ? { sunrise: formatTime(sunrises[i]) } : {}),
+        ...(typeof sunsets[i] === "string" ? { sunset: formatTime(sunsets[i]) } : {}),
       });
     });
   }
@@ -268,4 +268,13 @@ function titleCase(s: string): string {
     .split(/[\s_-]+/)
     .map((w) => (w ? w[0]!.toUpperCase() + w.slice(1) : w))
     .join(" ");
+}
+
+/**
+ * Extract HH:MM from an ISO 8601 timestamp string.
+ * "2026-01-01T06:52" → "06:52"
+ */
+function formatTime(iso: string): string {
+  const m = iso.match(/(\d{2}:\d{2})/);
+  return m ? m[1]! : iso;
 }


### PR DESCRIPTION
Update vendored weather skill from v0.3.2 → v0.3.3. Open-Meteo sunrise/sunset now renders as HH:MM instead of raw ISO 8601.