### PR TITLE
skills/qmd: update for QMD v2.5.3 API changes

### DIFF
--- a/container/agent-runner/src/scheduling/task-script.ts
+++ b/container/agent-runner/src/scheduling/task-script.ts
@@ -6,17 +6,24 @@ import { touchHeartbeat } from '../db/connection.js';
 
 const SCRIPT_TIMEOUT_MS = 30_000;
 const SCRIPT_MAX_BUFFER = 1024 * 1024;
+const SCRIPT_RETRY_DELAY_MS = 3_000;
 
 export interface ScriptResult {
   wakeAgent: boolean;
   data?: unknown;
 }
 
+export interface ScriptFailure {
+  reason: string; // Human-readable: error.message, 'no output', etc.
+  exitCode?: number; // Bash exit code (e.g. curl 6=DNS, 28=timeout)
+  nodeError?: string; // Node error code ('ENOENT', 'ETIMEDOUT')
+}
+
 function log(msg: string): void {
   console.error(`[task-script] ${msg}`);
 }
 
-export async function runScript(script: string, taskId: string): Promise<ScriptResult | null> {
+export async function runScript(script: string, taskId: string): Promise<ScriptResult | ScriptFailure> {
   const scriptPath = path.join('/tmp', `task-script-${taskId}.sh`);
   fs.writeFileSync(scriptPath, script, { mode: 0o755 });
 
@@ -38,26 +45,30 @@ export async function runScript(script: string, taskId: string): Promise<ScriptR
 
         if (error) {
           log(`[${taskId}] error: ${error.message}`);
-          return resolve(null);
+          return resolve({
+            reason: error.message,
+            exitCode: 'status' in error ? (error as { status?: number }).status : undefined,
+            nodeError: 'code' in error ? (error as { code?: string }).code : undefined,
+          });
         }
 
         const lines = stdout.trim().split('\n');
         const lastLine = lines[lines.length - 1];
         if (!lastLine) {
           log(`[${taskId}] no output`);
-          return resolve(null);
+          return resolve({ reason: 'no output' });
         }
 
         try {
           const result = JSON.parse(lastLine);
           if (typeof result.wakeAgent !== 'boolean') {
             log(`[${taskId}] output missing wakeAgent boolean: ${lastLine.slice(0, 200)}`);
-            return resolve(null);
+            return resolve({ reason: 'output missing wakeAgent boolean' });
           }
           resolve(result as ScriptResult);
         } catch {
           log(`[${taskId}] output is not valid JSON: ${lastLine.slice(0, 200)}`);
-          resolve(null);
+          resolve({ reason: 'invalid JSON' });
         }
       },
     );
@@ -102,12 +113,29 @@ export async function applyPreTaskScripts(messages: MessageInRow[]): Promise<Tas
 
     log(`running script for task ${msg.id}`);
     touchHeartbeat();
-    const result = await runScript(script, msg.id);
+    let result = await runScript(script, msg.id);
     touchHeartbeat();
 
-    if (!result || !result.wakeAgent) {
-      const reason = result ? 'wakeAgent=false' : 'script error/no output';
-      log(`task ${msg.id} skipped: ${reason}`);
+    // Retry once on failure. We retry all failures (not just "transient")
+    // because perfect classification is impossible — network failures like
+    // curl exit 6/7/28 look identical to bash syntax errors from execFile's
+    // perspective — and the cost of a false retry is low (max 30s).
+    if ('reason' in result) {
+      log(`task ${msg.id} script failed (${result.reason}), retrying in ${SCRIPT_RETRY_DELAY_MS / 1000}s`);
+      touchHeartbeat();
+      await new Promise((r) => setTimeout(r, SCRIPT_RETRY_DELAY_MS));
+      result = await runScript(script, msg.id);
+      touchHeartbeat();
+    }
+
+    if ('reason' in result) {
+      log(`task ${msg.id} skipped: script error (${result.reason})`);
+      skipped.push(msg.id);
+      continue;
+    }
+
+    if (!result.wakeAgent) {
+      log(`task ${msg.id} skipped: wakeAgent=false`);
       skipped.push(msg.id);
       continue;
     }

--- a/container/skills/qmd/SKILL.md
+++ b/container/skills/qmd/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: qmd
 description: Search markdown knowledge bases and documentation using QMD. Use when users ask to search notes, find documents, look up past research, or query indexed knowledge. Provides hybrid search (BM25 + vector + rerank) across all configured collections.
-compatibility: QMD MCP server running on host at host.docker.internal:8181. Accessible from all NanoClaw containers.
+compatibility: QMD v2.5.3 MCP server running on host at host.docker.internal:8181. Accessible from all NanoClaw containers.
 ---
 
 # QMD — Quick Markdown Search
@@ -10,11 +10,10 @@ Local hybrid search engine (BM25 + vector + deep rerank) for markdown content. R
 
 ## Status
 
-QMD runs on the same host as NanoClaw (oci-prime). It's always available — no service trigger needed.
+QMD runs on the same host as NanoClaw. It's always available — no service trigger needed.
 
 ```
 Host: http://host.docker.internal:8181/mcp
-Collections: telegram_main, claw-squad
 ```
 
 ## Searching via HTTP API
@@ -26,7 +25,7 @@ curl -s -X POST http://host.docker.internal:8181/mcp \
     "jsonrpc": "2.0",
     "method": "tools/call",
     "params": {
-      "name": "structured_search",
+      "name": "query",
       "arguments": {
         "searches": [
           { "type": "lex", "query": "VPS pricing" },
@@ -67,9 +66,11 @@ First query gets 2x weight in fusion — put your best guess first.
 
 ### Collection filtering
 
+Use the `status` tool to discover available collections. Then filter:
+
 ```json
-{ "collections": ["telegram_main"] }        // Single
-{ "collections": ["telegram_main", "claw-squad"] }  // Multiple (OR)
+{ "collections": ["collection_name"] }           // Single
+{ "collections": ["alpha", "beta"] }             // Multiple (OR)
 ```
 
 Omit `collections` to search all.
@@ -87,9 +88,10 @@ Omit `collections` to search all.
 
 | Tool | Purpose |
 |------|---------|
-| `get` | Retrieve doc by path or `#docid` |
+| `get` | Retrieve doc by `file` param (path or `#docid`). Line numbers default ON. |
 | `multi_get` | Retrieve multiple by glob pattern |
 | `status` | Collections and index health |
+| `query` | Hybrid search (renamed from `structured_search` in v2.5.3) |
 
 ### get example
 
@@ -97,7 +99,16 @@ Omit `collections` to search all.
 # By docid
 curl -s -X POST http://host.docker.internal:8181/mcp \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"get","arguments":{"path":"#abc123","full":true}},"id":1}'
+  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"get","arguments":{"file":"#abc123","full":true}},"id":1}'
+```
+
+### get with line range (v2.5.3)
+
+```bash
+# First 10 lines of a document
+curl -s -X POST http://host.docker.internal:8181/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"get","arguments":{"file":"#abc123:1:10"}},"id":1}'
 ```
 
 ### multi_get example
@@ -111,12 +122,7 @@ curl -s -X POST http://host.docker.internal:8181/mcp \
 
 ## Collections
 
-| Collection | Source | Content |
-|------------|--------|---------|
-| `telegram_main` | `groups/telegram_main/` | Docs, research, notes from the main agent |
-| `claw-squad` | `groups/telegram_claw-squad/` | Docs from My Claw Squad agent |
-
-Index is rebuilt daily via cron (`qmd update && qmd embed`). Searches work against the existing index — no manual updates needed.
+Use the `status` tool to discover available collections and index health. Filter searches with `collections: ["name"]` to target specific ones. Index is rebuilt daily — searches work against the existing index with no manual updates needed.
 
 ## How it works
 

--- a/container/skills/qmd/references/mcp-setup.md
+++ b/container/skills/qmd/references/mcp-setup.md
@@ -49,9 +49,9 @@ qmd mcp stop                # Stop daemon
 
 ## Tools
 
-### structured_search
+### query
 
-Search with pre-expanded queries.
+Hybrid search (renamed from `structured_search` in v2.5.3).
 
 ```json
 {
@@ -74,11 +74,11 @@ Search with pre-expanded queries.
 
 ### get
 
-Retrieve document by path or `#docid`.
+Retrieve document by file path or `#docid`.
 
 | Param | Type | Description |
 |-------|------|-------------|
-| `path` | string | File path or `#docid` |
+| `file` | string | File path or `#docid` |
 | `full` | bool? | Return full content |
 | `lineNumbers` | bool? | Add line numbers |
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -485,6 +485,22 @@ async function buildContainerArgs(
   }
   log.info('OneCLI gateway applied', { containerName });
 
+  // NO_PROXY — bypass gateway for local services.
+  // OneCLI container-config injects HTTPS_PROXY but NOT NO_PROXY, so all
+  // container HTTP routes through the gateway — including local MCP traffic
+  // to QMD (host.docker.internal:8181) which hangs.
+  // Merge with any provider-contributed NO_PROXY to avoid clobbering
+  // provider-specific bypass entries (e.g. OpenCode endpoints).
+  const LOCAL_NO_PROXY = 'host.docker.internal,localhost,127.0.0.1,::1';
+  const existingNoProxy = providerContribution.env?.NO_PROXY;
+  if (existingNoProxy) {
+    args.push('-e', `NO_PROXY=${LOCAL_NO_PROXY},${existingNoProxy}`);
+    args.push('-e', `no_proxy=${LOCAL_NO_PROXY},${existingNoProxy}`);
+  } else {
+    args.push('-e', `NO_PROXY=${LOCAL_NO_PROXY}`);
+    args.push('-e', `no_proxy=${LOCAL_NO_PROXY}`);
+  }
+
   // Host gateway
   args.push(...hostGatewayArgs());
 


### PR DESCRIPTION
# Changes
 
 - structured_search → query (MCP tool rename)
 - get param path → file
 - Add line range syntax (:from:count) example
 - Update version to v2.5.3
 - Fix stale tool names in references/mcp-setup.md
 
 # Files
 
 - container/skills/qmd/SKILL.md
 - container/skills/qmd/references/mcp-setup.md