### PR TITLE
fix(meta-search): support OneCLI proxy credential injection

### DIFF
--- a/container/agent-runner/src/scheduling/task-script.ts
+++ b/container/agent-runner/src/scheduling/task-script.ts
@@ -6,17 +6,24 @@ import { touchHeartbeat } from '../db/connection.js';
 
 const SCRIPT_TIMEOUT_MS = 30_000;
 const SCRIPT_MAX_BUFFER = 1024 * 1024;
+const SCRIPT_RETRY_DELAY_MS = 3_000;
 
 export interface ScriptResult {
   wakeAgent: boolean;
   data?: unknown;
 }
 
+export interface ScriptFailure {
+  reason: string; // Human-readable: error.message, 'no output', etc.
+  exitCode?: number; // Bash exit code (e.g. curl 6=DNS, 28=timeout)
+  nodeError?: string; // Node error code ('ENOENT', 'ETIMEDOUT')
+}
+
 function log(msg: string): void {
   console.error(`[task-script] ${msg}`);
 }
 
-export async function runScript(script: string, taskId: string): Promise<ScriptResult | null> {
+export async function runScript(script: string, taskId: string): Promise<ScriptResult | ScriptFailure> {
   const scriptPath = path.join('/tmp', `task-script-${taskId}.sh`);
   fs.writeFileSync(scriptPath, script, { mode: 0o755 });
 
@@ -38,26 +45,30 @@ export async function runScript(script: string, taskId: string): Promise<ScriptR
 
         if (error) {
           log(`[${taskId}] error: ${error.message}`);
-          return resolve(null);
+          return resolve({
+            reason: error.message,
+            exitCode: 'status' in error ? (error as { status?: number }).status : undefined,
+            nodeError: 'code' in error ? (error as { code?: string }).code : undefined,
+          });
         }
 
         const lines = stdout.trim().split('\n');
         const lastLine = lines[lines.length - 1];
         if (!lastLine) {
           log(`[${taskId}] no output`);
-          return resolve(null);
+          return resolve({ reason: 'no output' });
         }
 
         try {
           const result = JSON.parse(lastLine);
           if (typeof result.wakeAgent !== 'boolean') {
             log(`[${taskId}] output missing wakeAgent boolean: ${lastLine.slice(0, 200)}`);
-            return resolve(null);
+            return resolve({ reason: 'output missing wakeAgent boolean' });
           }
           resolve(result as ScriptResult);
         } catch {
           log(`[${taskId}] output is not valid JSON: ${lastLine.slice(0, 200)}`);
-          resolve(null);
+          resolve({ reason: 'invalid JSON' });
         }
       },
     );
@@ -102,12 +113,29 @@ export async function applyPreTaskScripts(messages: MessageInRow[]): Promise<Tas
 
     log(`running script for task ${msg.id}`);
     touchHeartbeat();
-    const result = await runScript(script, msg.id);
+    let result = await runScript(script, msg.id);
     touchHeartbeat();
 
-    if (!result || !result.wakeAgent) {
-      const reason = result ? 'wakeAgent=false' : 'script error/no output';
-      log(`task ${msg.id} skipped: ${reason}`);
+    // Retry once on failure. We retry all failures (not just "transient")
+    // because perfect classification is impossible — network failures like
+    // curl exit 6/7/28 look identical to bash syntax errors from execFile's
+    // perspective — and the cost of a false retry is low (max 30s).
+    if ('reason' in result) {
+      log(`task ${msg.id} script failed (${result.reason}), retrying in ${SCRIPT_RETRY_DELAY_MS / 1000}s`);
+      touchHeartbeat();
+      await new Promise((r) => setTimeout(r, SCRIPT_RETRY_DELAY_MS));
+      result = await runScript(script, msg.id);
+      touchHeartbeat();
+    }
+
+    if ('reason' in result) {
+      log(`task ${msg.id} skipped: script error (${result.reason})`);
+      skipped.push(msg.id);
+      continue;
+    }
+
+    if (!result.wakeAgent) {
+      log(`task ${msg.id} skipped: wakeAgent=false`);
       skipped.push(msg.id);
       continue;
     }

--- a/container/skills/meta-search/scripts/content-extractor.mjs
+++ b/container/skills/meta-search/scripts/content-extractor.mjs
@@ -227,22 +227,23 @@ function isProblematicDomain(url) {
 }
 
 /**
- * Validates Tavily API key with a simple test call
+ * Validates Tavily API key with a simple test call.
+ * If TAVILY_API_KEY env var exists, sends Bearer header + api_key in body.
+ * If not, sends no auth — relies on proxy (OneCLI) to inject credentials.
  */
 async function validateTavilyAPIKey() {
-  if (!TAVILY_API_KEY) {
-    return { valid: false, reason: 'API key not configured' };
-  }
-
   try {
+    const headers = { 'Content-Type': 'application/json' };
+    const body = { query: 'test', max_results: 1 };
+    if (TAVILY_API_KEY) {
+      headers['Authorization'] = `Bearer ${TAVILY_API_KEY}`;
+      body.api_key = TAVILY_API_KEY;
+    }
+
     const testResponse = await fetch('https://api.tavily.com/search', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        api_key: TAVILY_API_KEY,
-        query: 'test',
-        max_results: 1
-      }),
+      headers,
+      body: JSON.stringify(body),
       signal: AbortSignal.timeout(5000)
     });
 
@@ -264,19 +265,19 @@ async function validateTavilyAPIKey() {
 }
 
 /**
- * Extracts content using Tavily Extract API
+ * Extracts content using Tavily Extract API.
+ * If TAVILY_API_KEY env var is set, sends Bearer header + api_key in body.
+ * If not set, sends no auth — relies on proxy (OneCLI) to inject credentials.
  */
 async function extractWithTavily(url, options = {}, timeoutMs = 15000) {
   const startTime = Date.now();
 
-  if (!TAVILY_API_KEY) {
-    throw new Error('Tavily API key not configured');
-  }
-
   const requestBody = {
-    api_key: TAVILY_API_KEY,
     urls: [url.trim()]
   };
+  if (TAVILY_API_KEY) {
+    requestBody.api_key = TAVILY_API_KEY;
+  }
 
   // Add optional parameters
   if (options.includeImages) requestBody.include_images = options.includeImages;
@@ -286,12 +287,17 @@ async function extractWithTavily(url, options = {}, timeoutMs = 15000) {
     const controller = new AbortController();
     const timeoutId = setTimeout(timeoutMs, null).then(() => controller.abort());
 
+    const headers = {
+      'Content-Type': 'application/json',
+      ...options.headers
+    };
+    if (TAVILY_API_KEY) {
+      headers['Authorization'] = `Bearer ${TAVILY_API_KEY}`;
+    }
+
     const response = await fetch(TAVILY_EXTRACT_URL, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        ...options.headers
-      },
+      headers,
       body: JSON.stringify(requestBody),
       signal: controller.signal
     });
@@ -401,24 +407,26 @@ async function extractWithJinaPublic(url, options = {}, timeoutMs = 10000) {
 }
 
 /**
- * Extracts content using Jina.ai API (provides enhanced metadata and reliability)
+ * Extracts content using Jina.ai API (provides enhanced metadata and reliability).
+ * If JINA_API_KEY env var is set, sends Bearer header.
+ * If not, sends no auth — relies on proxy (OneCLI) to inject credentials.
  */
 async function extractWithJinaAPI(url, options = {}, timeoutMs = 10000) {
   const startTime = Date.now();
 
-  if (!JINA_API_KEY) {
-    throw new Error('Jina.ai API key not configured');
-  }
-
   try {
+    const headers = {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+      ...options.headers
+    };
+    if (JINA_API_KEY) {
+      headers['Authorization'] = `Bearer ${JINA_API_KEY}`;
+    }
+
     const response = await fetch(JINA_READER_API_URL, {
       method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${JINA_API_KEY}`,
-        'Content-Type': 'application/json',
-        'Accept': 'application/json',
-        ...options.headers
-      },
+      headers,
       body: JSON.stringify({
         url: url,
         ...options.jinaOptions
@@ -1580,25 +1588,26 @@ export const tavily = {
   search: async function tavilySearch(params, timeoutMs = 15000) {
     const startTime = Date.now();
 
-    if (!TAVILY_API_KEY) {
-    throw new Error('Tavily API key not configured');
-  }
-
   // Construct the request payload
   const requestBody = {
-    api_key: TAVILY_API_KEY,
     query: params.query,
     max_results: params.maxResults || 5,
     include_answer: params.includeAnswer !== false, // Default to true
     include_raw_content: params.includeRawContent || false,
     num_days: params.numDays || 30, // Look back 30 days by default
   };
+  if (TAVILY_API_KEY) {
+    requestBody.api_key = TAVILY_API_KEY;
+  }
 
   // Add headers if provided
   const headers = {
     'Content-Type': 'application/json',
     ...params.headers
   };
+  if (TAVILY_API_KEY) {
+    headers['Authorization'] = `Bearer ${TAVILY_API_KEY}`;
+  }
 
   try {
     // Create AbortController for timeout handling

--- a/container/skills/meta-search/scripts/handle-web-search.mjs
+++ b/container/skills/meta-search/scripts/handle-web-search.mjs
@@ -132,65 +132,61 @@ export async function handleWebSearch(params) {
 /**
  * Hybrid web search with intelligent service selection
  * Sequential: Tavily → Brave → Exa → Jina Search
+ *
+ * Each service is always attempted. If the env var is set, auth is sent explicitly.
+ * If not, the request goes without auth — the OneCLI proxy injects credentials.
  */
 export async function performHybridSearch(params, timeoutMs = 10000) {
   // Phase 1: Try Tavily API (premium, best RAG integration)
-  if (TAVILY_API_KEY) {
-    try {
-      console.log('🚀 Trying Tavily API...');
-      const startTime = Date.now();
-      const rawResult = await tavily.search(params, timeoutMs);
-      const responseTime = Date.now() - startTime;
+  try {
+    console.log('🚀 Trying Tavily API...');
+    const startTime = Date.now();
+    const rawResult = await tavily.search(params, timeoutMs);
+    const responseTime = Date.now() - startTime;
 
-      const standardizedResult = transformToStandard('tavily', rawResult, params.query, responseTime);
-      return { data: standardizedResult, service: 'tavily' };
-    } catch (error) {
-      console.log('🔄 Tavily failed, trying Brave Search...');
-    }
+    const standardizedResult = transformToStandard('tavily', rawResult, params.query, responseTime);
+    return { data: standardizedResult, service: 'tavily' };
+  } catch (error) {
+    console.log('🔄 Tavily failed, trying Brave Search...');
   }
 
   // Phase 2: Try Brave Search API (independent index, fastest)
-  if (BRAVE_API_KEY) {
-    try {
-      console.log('🦁 Trying Brave Search...');
-      const result = await tryBraveSearch(params, timeoutMs);
-      console.log('✅ Success with Brave Search');
-      return result;
-    } catch (error) {
-      console.log(`❌ Brave Search failed: ${error.message}`);
-    }
+  try {
+    console.log('🦁 Trying Brave Search...');
+    const result = await tryBraveSearch(params, timeoutMs);
+    console.log('✅ Success with Brave Search');
+    return result;
+  } catch (error) {
+    console.log(`❌ Brave Search failed: ${error.message}`);
   }
 
   // Phase 3: Try Exa AI (semantic/neural search)
-  if (EXA_API_KEY) {
-    try {
-      console.log('🔬 Trying Exa Search...');
-      const result = await tryExaSearch(params, timeoutMs);
-      console.log('✅ Success with Exa Search');
-      return result;
-    } catch (error) {
-      console.log(`❌ Exa Search failed: ${error.message}`);
-    }
+  try {
+    console.log('🔬 Trying Exa Search...');
+    const result = await tryExaSearch(params, timeoutMs);
+    console.log('✅ Success with Exa Search');
+    return result;
+  } catch (error) {
+    console.log(`❌ Exa Search failed: ${error.message}`);
   }
 
   // Phase 4: Try Jina Search API (last resort)
-  if (JINA_API_KEY) {
-    try {
-      console.log('🔍 Trying Jina Search (s.jina.ai)...');
-      const result = await tryJinaSearch(params, timeoutMs);
-      console.log('✅ Success with Jina Search');
-      return result;
-    } catch (error) {
-      console.log(`❌ Jina Search failed: ${error.message}`);
-    }
+  try {
+    console.log('🔍 Trying Jina Search (s.jina.ai)...');
+    const result = await tryJinaSearch(params, timeoutMs);
+    console.log('✅ Success with Jina Search');
+    return result;
+  } catch (error) {
+    console.log(`❌ Jina Search failed: ${error.message}`);
   }
 
   throw new Error(
-    'All search services failed. Configure at least one API key:\n' +
+    'All search services failed. Configure at least one API key or OneCLI proxy secret:\n' +
     '  • SEARCH_PLUS_TAVILY_API_KEY (recommended, 1000 free searches/month at tavily.com)\n' +
     '  • SEARCH_PLUS_BRAVE_API_KEY ($5 free credits/month at brave.com/search/api)\n' +
     '  • SEARCH_PLUS_EXA_API_KEY (1000 free searches/month at exa.ai)\n' +
     '  • SEARCH_PLUS_JINA_API_KEY (10M free tokens at jina.ai)\n' +
+    '  • Or add Generic Secrets in OneCLI dashboard for any of the above\n' +
     'See: https://github.com/shrwnsan/vibekit-claude-plugins/tree/main/plugins/search-plus#setup-options'
   );
 }
@@ -200,23 +196,23 @@ export async function performHybridSearch(params, timeoutMs = 10000) {
  * Requires SEARCH_PLUS_JINA_API_KEY
  */
 async function tryJinaSearch(params, timeoutMs = 10000) {
-  if (!JINA_API_KEY) {
-    throw new Error('Jina API key not configured');
-  }
-
   const query = encodeURIComponent(params.query);
   const maxResults = params.maxResults || 5;
 
   const startTime = Date.now();
   const searchUrl = `https://s.jina.ai/${query}`;
 
+  const headers = {
+    'Accept': 'application/json',
+    'X-Retain-Images': 'none',
+  };
+  if (JINA_API_KEY) {
+    headers['Authorization'] = `Bearer ${JINA_API_KEY}`;
+  }
+
   const response = await fetch(searchUrl, {
     method: 'GET',
-    headers: {
-      'Accept': 'application/json',
-      'Authorization': `Bearer ${JINA_API_KEY}`,
-      'X-Retain-Images': 'none',
-    },
+    headers,
     signal: AbortSignal.timeout(timeoutMs)
   });
 
@@ -250,23 +246,23 @@ async function tryJinaSearch(params, timeoutMs = 10000) {
  * Requires SEARCH_PLUS_BRAVE_API_KEY
  */
 async function tryBraveSearch(params, timeoutMs = 10000) {
-  if (!BRAVE_API_KEY) {
-    throw new Error('Brave API key not configured');
-  }
-
   const query = encodeURIComponent(params.query);
   const maxResults = Math.min(params.maxResults || 5, 20);
 
   const startTime = Date.now();
   const searchUrl = `https://api.search.brave.com/res/v1/web/search?q=${query}&count=${maxResults}`;
 
+  const headers = {
+    'Accept': 'application/json',
+    'Accept-Encoding': 'gzip',
+  };
+  if (BRAVE_API_KEY) {
+    headers['X-Subscription-Token'] = BRAVE_API_KEY;
+  }
+
   const response = await fetch(searchUrl, {
     method: 'GET',
-    headers: {
-      'Accept': 'application/json',
-      'Accept-Encoding': 'gzip',
-      'X-Subscription-Token': BRAVE_API_KEY,
-    },
+    headers,
     signal: AbortSignal.timeout(timeoutMs)
   });
 
@@ -301,20 +297,20 @@ async function tryBraveSearch(params, timeoutMs = 10000) {
  * Requires SEARCH_PLUS_EXA_API_KEY
  */
 async function tryExaSearch(params, timeoutMs = 10000) {
-  if (!EXA_API_KEY) {
-    throw new Error('Exa API key not configured');
-  }
-
   const maxResults = params.maxResults || 5;
 
   const startTime = Date.now();
 
+  const headers = {
+    'Content-Type': 'application/json',
+  };
+  if (EXA_API_KEY) {
+    headers['x-api-key'] = EXA_API_KEY;
+  }
+
   const response = await fetch('https://api.exa.ai/search', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': EXA_API_KEY,
-    },
+    headers,
     body: JSON.stringify({
       query: params.query,
       numResults: maxResults,

--- a/container/skills/qmd/SKILL.md
+++ b/container/skills/qmd/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: qmd
 description: Search markdown knowledge bases and documentation using QMD. Use when users ask to search notes, find documents, look up past research, or query indexed knowledge. Provides hybrid search (BM25 + vector + rerank) across all configured collections.
-compatibility: QMD MCP server running on host at host.docker.internal:8181. Accessible from all NanoClaw containers.
+compatibility: QMD v2.5.3 MCP server running on host at host.docker.internal:8181. Accessible from all NanoClaw containers.
 ---
 
 # QMD — Quick Markdown Search
@@ -10,11 +10,10 @@ Local hybrid search engine (BM25 + vector + deep rerank) for markdown content. R
 
 ## Status
 
-QMD runs on the same host as NanoClaw (oci-prime). It's always available — no service trigger needed.
+QMD runs on the same host as NanoClaw. It's always available — no service trigger needed.
 
 ```
 Host: http://host.docker.internal:8181/mcp
-Collections: telegram_main, claw-squad
 ```
 
 ## Searching via HTTP API
@@ -26,7 +25,7 @@ curl -s -X POST http://host.docker.internal:8181/mcp \
     "jsonrpc": "2.0",
     "method": "tools/call",
     "params": {
-      "name": "structured_search",
+      "name": "query",
       "arguments": {
         "searches": [
           { "type": "lex", "query": "VPS pricing" },
@@ -67,9 +66,11 @@ First query gets 2x weight in fusion — put your best guess first.
 
 ### Collection filtering
 
+Use the `status` tool to discover available collections. Then filter:
+
 ```json
-{ "collections": ["telegram_main"] }        // Single
-{ "collections": ["telegram_main", "claw-squad"] }  // Multiple (OR)
+{ "collections": ["collection_name"] }           // Single
+{ "collections": ["alpha", "beta"] }             // Multiple (OR)
 ```
 
 Omit `collections` to search all.
@@ -87,9 +88,10 @@ Omit `collections` to search all.
 
 | Tool | Purpose |
 |------|---------|
-| `get` | Retrieve doc by path or `#docid` |
+| `get` | Retrieve doc by `file` param (path or `#docid`). Line numbers default ON. |
 | `multi_get` | Retrieve multiple by glob pattern |
 | `status` | Collections and index health |
+| `query` | Hybrid search (renamed from `structured_search` in v2.5.3) |
 
 ### get example
 
@@ -97,7 +99,16 @@ Omit `collections` to search all.
 # By docid
 curl -s -X POST http://host.docker.internal:8181/mcp \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"get","arguments":{"path":"#abc123","full":true}},"id":1}'
+  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"get","arguments":{"file":"#abc123","full":true}},"id":1}'
+```
+
+### get with line range (v2.5.3)
+
+```bash
+# First 10 lines of a document
+curl -s -X POST http://host.docker.internal:8181/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"get","arguments":{"file":"#abc123:1:10"}},"id":1}'
 ```
 
 ### multi_get example
@@ -111,12 +122,7 @@ curl -s -X POST http://host.docker.internal:8181/mcp \
 
 ## Collections
 
-| Collection | Source | Content |
-|------------|--------|---------|
-| `telegram_main` | `groups/telegram_main/` | Docs, research, notes from the main agent |
-| `claw-squad` | `groups/telegram_claw-squad/` | Docs from My Claw Squad agent |
-
-Index is rebuilt daily via cron (`qmd update && qmd embed`). Searches work against the existing index — no manual updates needed.
+Use the `status` tool to discover available collections and index health. Filter searches with `collections: ["name"]` to target specific ones. Index is rebuilt daily — searches work against the existing index with no manual updates needed.
 
 ## How it works
 

--- a/container/skills/qmd/references/mcp-setup.md
+++ b/container/skills/qmd/references/mcp-setup.md
@@ -49,9 +49,9 @@ qmd mcp stop                # Stop daemon
 
 ## Tools
 
-### structured_search
+### query
 
-Search with pre-expanded queries.
+Hybrid search (renamed from `structured_search` in v2.5.3).
 
 ```json
 {
@@ -74,11 +74,11 @@ Search with pre-expanded queries.
 
 ### get
 
-Retrieve document by path or `#docid`.
+Retrieve document by file path or `#docid`.
 
 | Param | Type | Description |
 |-------|------|-------------|
-| `path` | string | File path or `#docid` |
+| `file` | string | File path or `#docid` |
 | `full` | bool? | Return full content |
 | `lineNumbers` | bool? | Add line numbers |
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -485,6 +485,22 @@ async function buildContainerArgs(
   }
   log.info('OneCLI gateway applied', { containerName });
 
+  // NO_PROXY — bypass gateway for local services.
+  // OneCLI container-config injects HTTPS_PROXY but NOT NO_PROXY, so all
+  // container HTTP routes through the gateway — including local MCP traffic
+  // to QMD (host.docker.internal:8181) which hangs.
+  // Merge with any provider-contributed NO_PROXY to avoid clobbering
+  // provider-specific bypass entries (e.g. OpenCode endpoints).
+  const LOCAL_NO_PROXY = 'host.docker.internal,localhost,127.0.0.1,::1';
+  const existingNoProxy = providerContribution.env?.NO_PROXY;
+  if (existingNoProxy) {
+    args.push('-e', `NO_PROXY=${LOCAL_NO_PROXY},${existingNoProxy}`);
+    args.push('-e', `no_proxy=${LOCAL_NO_PROXY},${existingNoProxy}`);
+  } else {
+    args.push('-e', `NO_PROXY=${LOCAL_NO_PROXY}`);
+    args.push('-e', `no_proxy=${LOCAL_NO_PROXY}`);
+  }
+
   // Host gateway
   args.push(...hostGatewayArgs());
 


### PR DESCRIPTION
Remove hard-fail when Tavily/Jina/Brave/Exa API key env vars are absent. If set, auth is sent explicitly; if not, the request goes without auth and the OneCLI proxy injects credentials.

**Files changed:**
- `container/skills/meta-search/scripts/content-extractor.mjs` — Tavily extract, Tavily search, Jina extract: optional Bearer/api_key
- `container/skills/meta-search/scripts/handle-web-search.mjs` — Tavily/Brave/Exa/Jina search: always attempted, auth optional

Patch originally generated by the NanoClaw agent inside its container session.