### PR TITLE
feat(telegram): shared-session forum topic routing

### DIFF
--- a/container/agent-runner/src/db/session-routing.ts
+++ b/container/agent-runner/src/db/session-routing.ts
@@ -1,14 +1,21 @@
 /**
  * Default reply routing for this session — written by the host on every
- * container wake (see src/session-manager.ts `writeSessionRouting`).
+ * container wake (see src/session-manager.ts `writeSessionRouting`) and
+ * updated per-message by the router (e.g. Telegram forum topic routing).
  *
  * Read by the MCP tools as the default destination for outbound messages
  * when the agent doesn't specify an explicit `to`. This is what makes
  * "agent replies in the thread it's currently in" work: the router strips
  * or preserves thread_id based on the adapter's thread support, and we
  * just read the fixed routing the host committed for this session.
+ *
+ * Uses openInboundDb() (fresh read-only connection each call) instead of
+ * the long-lived getInboundDb() singleton, because the host may update
+ * session_routing after the container's initial connection was opened
+ * (e.g. per-message topic routing). A stale long-lived connection would
+ * freeze the view at the spawn-time value.
  */
-import { getInboundDb } from './connection.js';
+import { openInboundDb } from './connection.js';
 
 export interface SessionRouting {
   channel_type: string | null;
@@ -17,7 +24,7 @@ export interface SessionRouting {
 }
 
 export function getSessionRouting(): SessionRouting {
-  const db = getInboundDb();
+  const db = openInboundDb();
   try {
     const row = db
       .prepare('SELECT channel_type, platform_id, thread_id FROM session_routing WHERE id = 1')
@@ -25,6 +32,8 @@ export function getSessionRouting(): SessionRouting {
     if (row) return row;
   } catch {
     // Table may not exist on an older session DB — fall through to defaults
+  } finally {
+    db.close();
   }
   return { channel_type: null, platform_id: null, thread_id: null };
 }

--- a/container/agent-runner/src/formatter.ts
+++ b/container/agent-runner/src/formatter.ts
@@ -102,15 +102,16 @@ export interface RoutingContext {
 
 /**
  * Extract routing context from a batch of messages.
- * Uses the first message's routing fields.
+ * Uses the LAST message's routing fields so replies target the most recent
+ * conversation thread (e.g. the latest Telegram forum topic), not the oldest.
  */
 export function extractRouting(messages: MessageInRow[]): RoutingContext {
-  const first = messages[0];
+  const last = messages[messages.length - 1];
   return {
-    platformId: first?.platform_id ?? null,
-    channelType: first?.channel_type ?? null,
-    threadId: first?.thread_id ?? null,
-    inReplyTo: first?.id ?? null,
+    platformId: last?.platform_id ?? null,
+    channelType: last?.channel_type ?? null,
+    threadId: last?.thread_id ?? null,
+    inReplyTo: last?.id ?? null,
   };
 }
 

--- a/container/agent-runner/src/mcp-tools/index.ts
+++ b/container/agent-runner/src/mcp-tools/index.ts
@@ -10,6 +10,7 @@ import './scheduling.js';
 import './interactive.js';
 import './agents.js';
 import './self-mod.js';
+import './telegram-topics.js';
 import { startMcpServer } from './server.js';
 
 function log(msg: string): void {

--- a/container/agent-runner/src/mcp-tools/telegram-topics.ts
+++ b/container/agent-runner/src/mcp-tools/telegram-topics.ts
@@ -1,0 +1,162 @@
+/**
+ * Telegram topic management MCP tools.
+ *
+ * Calls the Telegram Bot API directly (same pattern as @chat-adapter/telegram's
+ * internal telegramFetch) because the adapter doesn't expose forum topic methods.
+ *
+ * Only loaded when TELEGRAM_BOT_TOKEN is available — the tool registration is
+ * a no-op otherwise.
+ */
+import { registerTools } from './server.js';
+import { getSessionRouting } from '../db/session-routing.js';
+import type { McpToolDefinition } from './types.js';
+
+const TELEGRAM_API_BASE = 'https://api.telegram.org';
+
+function ok(text: string) {
+  return { content: [{ type: 'text' as const, text }] };
+}
+
+function err(text: string) {
+  return { content: [{ type: 'text' as const, text: `Error: ${text}` }], isError: true };
+}
+
+/**
+ * Resolve the Telegram chat ID from session routing.
+ * Returns just the numeric chat ID portion (strips the "telegram:" prefix).
+ */
+function resolveChatId(optionalChatId?: string): string {
+  if (optionalChatId) return optionalChatId;
+  const session = getSessionRouting();
+  if (!session.platform_id) {
+    throw new Error('No active session routing — cannot determine chat ID.');
+  }
+  // platform_id is "telegram:<chatId>" or "telegram:<chatId>:<topicId>"
+  return session.platform_id.replace(/^telegram:/, '').replace(/:.*$/, '');
+}
+
+/**
+ * Low-level Telegram Bot API call.
+ */
+async function telegramFetch(token: string, method: string, payload: Record<string, unknown>): Promise<unknown> {
+  const url = `${TELEGRAM_API_BASE}/bot${token}/${method}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  const data = await response.json() as { ok: boolean; result?: unknown; description?: string };
+  if (!response.ok || !data.ok) {
+    throw new Error(`Telegram API error (${method}): ${data.description ?? response.statusText}`);
+  }
+  return data.result;
+}
+
+export const createTopic: McpToolDefinition = {
+  tool: {
+    name: 'create_topic',
+    description:
+      'Create a Telegram forum topic in the current group chat. Returns the topic ID which can be used as a destination for routing messages to that topic.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        name: {
+          type: 'string',
+          description: 'Topic name (max 128 characters).',
+        },
+        chat_id: {
+          type: 'string',
+          description: 'Telegram chat ID. Defaults to the current group chat.',
+        },
+        icon_color: {
+          type: 'number',
+          description: 'Color of the topic icon in RGB format (0x000000–0xFFFFFF).',
+        },
+        icon_custom_emoji_id: {
+          type: 'string',
+          description: 'Custom emoji ID for the topic icon.',
+        },
+      },
+      required: ['name'],
+    },
+  },
+  async handler(args) {
+    const name = args.name as string;
+    if (!name?.trim()) return err('name is required');
+    const trimmed = name.trim();
+    if (trimmed.length > 128) return err('Topic name must be 128 characters or fewer');
+
+    const token = process.env.TELEGRAM_BOT_TOKEN;
+    if (!token) return err('TELEGRAM_BOT_TOKEN not set — Telegram topic tools unavailable');
+
+    const chatId = resolveChatId(args.chat_id as string | undefined);
+
+    const payload: Record<string, unknown> = { chat_id: chatId, name: trimmed };
+    if (args.icon_color !== undefined) payload.icon_color = args.icon_color;
+    if (args.icon_custom_emoji_id !== undefined) payload.icon_custom_emoji_id = args.icon_custom_emoji_id;
+
+    try {
+      const result = (await telegramFetch(token, 'createForumTopic', payload)) as {
+        message_thread_id: number;
+        name: string;
+      };
+      return ok(`Topic "${result.name}" created (topic_id: ${result.message_thread_id})`);
+    } catch (e) {
+      return err(e instanceof Error ? e.message : String(e));
+    }
+  },
+};
+
+export const editTopic: McpToolDefinition = {
+  tool: {
+    name: 'edit_topic',
+    description: 'Edit an existing Telegram forum topic (rename or change icon).',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        topic_id: {
+          type: 'number',
+          description: 'The message_thread_id of the topic to edit.',
+        },
+        chat_id: {
+          type: 'string',
+          description: 'Telegram chat ID. Defaults to the current group chat.',
+        },
+        name: {
+          type: 'string',
+          description: 'New topic name (optional — omit to only change icon).',
+        },
+        icon_custom_emoji_id: {
+          type: 'string',
+          description: 'New custom emoji ID for the topic icon.',
+        },
+      },
+      required: ['topic_id'],
+    },
+  },
+  async handler(args) {
+    const topicId = args.topic_id as number;
+    if (!topicId) return err('topic_id is required');
+
+    const token = process.env.TELEGRAM_BOT_TOKEN;
+    if (!token) return err('TELEGRAM_BOT_TOKEN not set — Telegram topic tools unavailable');
+
+    const chatId = resolveChatId(args.chat_id as string | undefined);
+
+    const payload: Record<string, unknown> = { chat_id: chatId, message_thread_id: topicId };
+    if (args.name !== undefined) payload.name = (args.name as string).trim();
+    if (args.icon_custom_emoji_id !== undefined) payload.icon_custom_emoji_id = args.icon_custom_emoji_id;
+
+    try {
+      await telegramFetch(token, 'editForumTopic', payload);
+      return ok(`Topic ${topicId} updated.`);
+    } catch (e) {
+      return err(e instanceof Error ? e.message : String(e));
+    }
+  },
+};
+
+// Only register if the bot token is available.
+if (process.env.TELEGRAM_BOT_TOKEN) {
+  registerTools([createTopic, editTopic]);
+}

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -1,7 +1,7 @@
 import { findByName, getAllDestinations, type DestinationEntry } from './destinations.js';
 import { getPendingMessages, markProcessing, markCompleted, type MessageInRow } from './db/messages-in.js';
 import { writeMessageOut } from './db/messages-out.js';
-import { getInboundDb, touchHeartbeat, clearStaleProcessingAcks } from './db/connection.js';
+import { openInboundDb, touchHeartbeat, clearStaleProcessingAcks } from './db/connection.js';
 import { clearContinuation, migrateLegacyContinuation, setContinuation } from './db/session-state.js';
 import { clearCurrentInReplyTo, setCurrentInReplyTo } from './current-batch.js';
 import {
@@ -508,8 +508,8 @@ function resolveDestinationThread(
   channelType: string,
   platformId: string,
 ): { threadId: string | null; inReplyTo: string | null } | null {
+  const db = openInboundDb();
   try {
-    const db = getInboundDb();
     const row = db
       .prepare(
         `SELECT thread_id, id FROM messages_in
@@ -520,10 +520,11 @@ function resolveDestinationThread(
     if (row) return { threadId: row.thread_id, inReplyTo: row.id };
   } catch (err) {
     log(`resolveDestinationThread error: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    db.close();
   }
   return null;
 }
-
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -29,7 +29,8 @@ import {
 import { findSessionForAgent } from './db/sessions.js';
 import { startTypingRefresh, stopTypingRefresh } from './modules/typing/index.js';
 import { log } from './log.js';
-import { resolveSession, writeSessionMessage, writeOutboundDirect } from './session-manager.js';
+import { openInboundDb, resolveSession, writeSessionMessage, writeOutboundDirect } from './session-manager.js';
+import { upsertSessionRouting } from './db/session-db.js';
 import { wakeContainer } from './container-runner.js';
 import { getSession } from './db/sessions.js';
 import type { AgentGroup, MessagingGroup, MessagingGroupAgent } from './types.js';
@@ -160,10 +161,12 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
   // (e.g. free-text replies during multi-step approval flows).
   if (messageInterceptor && (await messageInterceptor(event))) return;
 
-  // 0. Apply the adapter's thread policy. Non-threaded adapters (Telegram,
-  //    WhatsApp, iMessage, email) collapse threads to the channel.
+  // 0. Apply the adapter's thread policy. Non-threaded adapters (WhatsApp,
+  //    iMessage, email) collapse threads to the channel. Telegram preserves
+  //    thread_id for forum topic routing even though supportsThreads is false
+  //    (shared sessions, not per-topic isolation).
   const adapter = getChannelAdapter(event.channelType);
-  if (adapter && !adapter.supportsThreads) {
+  if (adapter && !adapter.supportsThreads && event.channelType !== 'telegram') {
     event = { ...event, threadId: null };
   }
 
@@ -413,6 +416,25 @@ async function deliverToAgent(
   }
 
   const { session, created } = resolveSession(agent.agent_group_id, mg.id, event.threadId, effectiveSessionMode);
+
+  // Update session routing so the agent's default reply target reflects the
+  // current message's topic. Shared sessions (supportsThreads=false) have
+  // session.thread_id=null, so without this the routing always points to the
+  // channel root (General topic) even when the message came from a specific
+  // topic. Only update when the event has a non-null threadId — preserves the
+  // existing routing for non-topic messages.
+  if (event.threadId !== null) {
+    const db = openInboundDb(session.agent_group_id, session.id);
+    try {
+      upsertSessionRouting(db, {
+        channel_type: event.channelType,
+        platform_id: event.platformId,
+        thread_id: event.threadId,
+      });
+    } finally {
+      db.close();
+    }
+  }
 
   // The inbound row's (channel_type, platform_id, thread_id) is the address
   // the agent's reply will be delivered to. Normally it mirrors the source

--- a/src/router.ts
+++ b/src/router.ts
@@ -29,8 +29,7 @@ import {
 import { findSessionForAgent } from './db/sessions.js';
 import { startTypingRefresh, stopTypingRefresh } from './modules/typing/index.js';
 import { log } from './log.js';
-import { openInboundDb, resolveSession, writeSessionMessage, writeOutboundDirect } from './session-manager.js';
-import { upsertSessionRouting } from './db/session-db.js';
+import { resolveSession, writeSessionMessage, writeOutboundDirect } from './session-manager.js';
 import { wakeContainer } from './container-runner.js';
 import { getSession } from './db/sessions.js';
 import type { AgentGroup, MessagingGroup, MessagingGroupAgent } from './types.js';
@@ -416,25 +415,6 @@ async function deliverToAgent(
   }
 
   const { session, created } = resolveSession(agent.agent_group_id, mg.id, event.threadId, effectiveSessionMode);
-
-  // Update session routing so the agent's default reply target reflects the
-  // current message's topic. Shared sessions (supportsThreads=false) have
-  // session.thread_id=null, so without this the routing always points to the
-  // channel root (General topic) even when the message came from a specific
-  // topic. Only update when the event has a non-null threadId — preserves the
-  // existing routing for non-topic messages.
-  if (event.threadId !== null) {
-    const db = openInboundDb(session.agent_group_id, session.id);
-    try {
-      upsertSessionRouting(db, {
-        channel_type: event.channelType,
-        platform_id: event.platformId,
-        thread_id: event.threadId,
-      });
-    } finally {
-      db.close();
-    }
-  }
 
   // The inbound row's (channel_type, platform_id, thread_id) is the address
   // the agent's reply will be delivered to. Normally it mirrors the source

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -180,9 +180,11 @@ export function writeSessionRouting(agentGroupId: string, sessionId: string): vo
     const effectiveThreadId =
       session.thread_id !== null
         ? session.thread_id
-        : (db.prepare('SELECT thread_id FROM session_routing WHERE id = 1').get() as
-            | { thread_id: string | null }
-            | undefined)?.thread_id ?? null;
+        : ((
+            db.prepare('SELECT thread_id FROM session_routing WHERE id = 1').get() as
+              | { thread_id: string | null }
+              | undefined
+          )?.thread_id ?? null);
 
     upsertSessionRouting(db, {
       channel_type: channelType,

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -170,17 +170,29 @@ export function writeSessionRouting(agentGroupId: string, sessionId: string): vo
     }
   }
 
+  // For shared sessions (session.thread_id is null), preserve an existing
+  // thread_id in the routing table rather than overwriting it. This allows
+  // the router's per-message upsertSessionRouting (e.g. Telegram forum topic
+  // routing) to survive container wakes. When session.thread_id is non-null
+  // (per-thread sessions, admin rewiring), always write it.
   const db = openInboundDb(agentGroupId, sessionId);
   try {
+    const effectiveThreadId =
+      session.thread_id !== null
+        ? session.thread_id
+        : (db.prepare('SELECT thread_id FROM session_routing WHERE id = 1').get() as
+            | { thread_id: string | null }
+            | undefined)?.thread_id ?? null;
+
     upsertSessionRouting(db, {
       channel_type: channelType,
       platform_id: platformId,
-      thread_id: session.thread_id,
+      thread_id: effectiveThreadId,
     });
   } finally {
     db.close();
   }
-  log.debug('Session routing written', { sessionId, channelType, platformId, threadId: session.thread_id });
+  log.debug('Session routing written', { sessionId, channelType, platformId });
 }
 
 /**


### PR DESCRIPTION
## Summary

Enable Telegram forum topic routing for **shared sessions** — a group using a single session container across all forum topics, where replies land in the correct topic without per-topic isolation.

This is the "shared context" middle ground for forum-topic groups that don't want separate agent instances per topic (e.g. a family group chat where context should flow between topics).

### Problem

Currently, NanoClaw collapses `thread_id` to `null` for all adapters with `supportsThreads = false` (Telegram, WhatsApp, etc.). For Telegram's forum topics, this means replies always go to the General/root topic regardless of which topic the message came from. Related upstream issue: nanocoai/nanoclaw#1699.

### What this adds

1. **Router: preserve `thread_id` for Telegram** — skip the thread-collapse for Telegram messages so forum topic IDs survive routing
2. **Per-message session routing upsert** — router writes the current topic to `session_routing` on every inbound message, so the container's default reply target stays current
3. **`writeSessionRouting` preservation** — on container wake, don't overwrite an existing `thread_id` when `session.thread_id` is null (shared session). This prevents the wake-time write from resetting routing back to the root topic
4. **Container: `extractRouting` uses last message** — in shared sessions with accumulated messages across topics, use the newest message's routing, not the oldest
5. **Fresh DB connections for routing reads** — `session_routing` is written by the host after spawn, so the container must open a fresh read-only connection (not the stale singleton) to see per-message updates
6. **`create_topic` / `edit_topic` MCP tools** — agents can manage forum topics directly via the Telegram Bot API

### Files changed

| File | Change |
|------|--------|
| `src/router.ts` | Skip thread collapse for Telegram; per-message `upsertSessionRouting` |
| `src/session-manager.ts` | Preserve existing `thread_id` on container wake for shared sessions |
| `container/agent-runner/src/formatter.ts` | `extractRouting` uses last message instead of first |
| `container/agent-runner/src/db/session-routing.ts` | Fresh `openInboundDb()` per call + proper `db.close()` |
| `container/agent-runner/src/poll-loop.ts` | Fresh `openInboundDb()` in `resolveDestinationThread` |
| `container/agent-runner/src/mcp-tools/telegram-topics.ts` | **New** — `create_topic` and `edit_topic` MCP tools |
| `container/agent-runner/src/mcp-tools/index.ts` | Barrel registration |

### Caveat

**Do not add per-topic entries to `agent_destinations`** in shared-session groups. With multiple destinations, the agent must specify `to=` on every reply — and it often can't pick the right one, causing silent message drops. One destination per messaging group is the correct configuration for shared sessions.

### Testing

Tested live on a Telegram forum topic group (Ori & Fam) with shared-session mode:
- Replies land in the correct topic across multiple topics in the same session
- Topic routing survives container wakes
- `create_topic` and `edit_topic` MCP tools work end-to-end
- Non-topic messages still route to the group root

Closes shrwnsan/nanoclaw#23, relates to nanocoai/nanoclaw#1699