### PR TITLE
fix(scheduling): deterministic topic routing for scheduled tasks

### DIFF
--- a/container/agent-runner/src/integration.test.ts
+++ b/container/agent-runner/src/integration.test.ts
@@ -296,6 +296,64 @@ describe('poll loop integration', () => {
     await loopPromise.catch(() => {});
   });
 
+  it('task with thread_id routes outbound to that thread', async () => {
+    // Simulates a scheduled task that carries thread_id (e.g. a weather
+    // briefing targeting a specific Telegram forum topic).
+    // A stale user message from a different topic should NOT win — the
+    // task's thread_id is the latest message_in and resolveDestinationThread
+    // should return it.
+    getInboundDb()
+      .prepare(
+        `INSERT INTO messages_in (id, kind, timestamp, status, platform_id, channel_type, thread_id, content)
+         VALUES ('t-weather', 'task', datetime('now'), 'pending', 'chan-1', 'discord', 'topic-51', ?)`,
+      )
+      .run(JSON.stringify({ prompt: 'weather briefing' }));
+
+    const provider = new MockProvider({}, () => '<message to="discord-test">Sunny, 25°C</message>');
+    const controller = new AbortController();
+    const loopPromise = runPollLoopWithTimeout(provider, controller.signal, 2000);
+
+    await waitFor(() => getUndeliveredMessages().length > 0, 2000);
+    controller.abort();
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    expect(out[0].thread_id).toBe('topic-51');
+    expect(out[0].in_reply_to).toBe('t-weather');
+
+    await loopPromise.catch(() => {});
+  });
+
+  it('task thread_id takes priority over stale user message thread', async () => {
+    // Stale user message on topic-A, then a task with thread_id targeting topic-B.
+    // resolveDestinationThread picks the latest (the task), so outbound should
+    // go to topic-B, not topic-A.
+    insertMessage('m-old', { sender: 'Alice', text: 'from topic A' }, { platformId: 'chan-1', channelType: 'discord', threadId: 'topic-A' });
+
+    // Insert task with a higher seq (it's inserted after, so SQLite gives it a higher rowid)
+    // We use the insert helper pattern but force kind='task'
+    getInboundDb()
+      .prepare(
+        `INSERT INTO messages_in (id, kind, timestamp, status, platform_id, channel_type, thread_id, content)
+         VALUES ('t-target', 'task', datetime('now'), 'pending', 'chan-1', 'discord', 'topic-B', ?)`,
+      )
+      .run(JSON.stringify({ prompt: 'go to topic B' }));
+
+    const provider = new MockProvider({}, () => '<message to="discord-test">dispatched to B</message>');
+    const controller = new AbortController();
+    const loopPromise = runPollLoopWithTimeout(provider, controller.signal, 2000);
+
+    await waitFor(() => getUndeliveredMessages().length > 0, 2000);
+    controller.abort();
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1);
+    expect(out[0].thread_id).toBe('topic-B');
+    expect(out[0].in_reply_to).toBe('t-target');
+
+    await loopPromise.catch(() => {});
+  });
+
 });
 
 // Helper: run poll loop until aborted or timeout

--- a/container/agent-runner/src/mcp-tools/scheduling.ts
+++ b/container/agent-runner/src/mcp-tools/scheduling.ts
@@ -52,6 +52,11 @@ export const scheduleTask: McpToolDefinition = {
             'Cron expression for recurring tasks (e.g., "0 9 * * 1-5" = weekdays at 9am user-local). Evaluated in the user\'s timezone.',
         },
         script: { type: 'string', description: 'Optional pre-agent script to run before processing' },
+        threadId: {
+          type: 'string',
+          description:
+            'Optional thread/topic ID for the task message (e.g. "telegram:<chatId>:<topicId>"). When set, the task\'s response routes to this specific topic instead of the session\'s current topic. Use for scheduled tasks that should always deliver to a fixed forum topic.',
+        },
       },
       required: ['prompt', 'processAfter'],
     },
@@ -74,6 +79,7 @@ export const scheduleTask: McpToolDefinition = {
     const r = routing();
     const recurrence = (args.recurrence as string) || null;
     const script = (args.script as string) || null;
+    const threadId = (args.threadId as string) || r.thread_id;
 
     // Write as a system action — host will insert into inbound.db
     writeMessageOut({
@@ -81,7 +87,7 @@ export const scheduleTask: McpToolDefinition = {
       kind: 'system',
       platform_id: r.platform_id,
       channel_type: r.channel_type,
-      thread_id: r.thread_id,
+      thread_id: threadId,
       content: JSON.stringify({
         action: 'schedule_task',
         taskId: id,
@@ -91,7 +97,7 @@ export const scheduleTask: McpToolDefinition = {
         recurrence,
         platformId: r.platform_id,
         channelType: r.channel_type,
-        threadId: r.thread_id,
+        threadId: threadId,
       }),
     });
 
@@ -263,6 +269,10 @@ export const updateTask: McpToolDefinition = {
           type: 'string',
           description: 'New pre-agent script (optional). Pass empty string to clear.',
         },
+        threadId: {
+          type: 'string',
+          description: 'New thread/topic ID for the task (optional). Pass empty string to clear and use the session\'s current topic.',
+        },
       },
       required: ['taskId'],
     },
@@ -282,9 +292,10 @@ export const updateTask: McpToolDefinition = {
         return err(`invalid processAfter: ${args.processAfter}`);
       }
     }
-    // Empty string clears recurrence/script; undefined leaves them as-is.
+    // Empty string clears recurrence/script/threadId; undefined leaves them as-is.
     if (typeof args.recurrence === 'string') update.recurrence = args.recurrence === '' ? null : args.recurrence;
     if (typeof args.script === 'string') update.script = args.script === '' ? null : args.script;
+    if (typeof args.threadId === 'string') update.threadId = args.threadId === '' ? null : args.threadId;
 
     if (Object.keys(update).length === 1) return err('at least one field to update is required');
 

--- a/docs/telegram-topic-routing.md
+++ b/docs/telegram-topic-routing.md
@@ -47,7 +47,7 @@ Early versions updated `session_routing` on every inbound message. This was **re
 
 Per-topic entries in `agent_destinations` (e.g. separate entries for "alerts" and "log") cause the agent to fail silently. With multiple destinations, the agent must specify `to=` on every reply — and it often can't pick the right one, producing `<internal>` scratchpad instead of `<message>` blocks. One destination per messaging group is the correct configuration for shared sessions.
 
-## Known Gap: Scheduled Task Topic Routing
+## Scheduled Task Topic Routing
 
 ### Problem
 
@@ -55,38 +55,33 @@ Scheduled tasks (e.g., weather briefings) write to `messages_in` with `thread_id
 
 The result is **non-deterministic routing**: the task output goes to whatever topic was last active, not a configured destination.
 
-### Evidence
-
-| Date | Task seq | Last `messages_in` topic | `thread_id` on output | Destination |
-|------|----------|--------------------------|----------------------|-------------|
-| July 1 (seq 167) | 116 | General (seq 118) | `null` | General (wrong) |
-| July 2 (seq 177) | 152 | Alerts (seq 158, from 15:13 HKT) | `:51` | Alerts (correct — by coincidence) |
-
 ### Root cause
 
-`resolveDestinationThread` has no status filter, no time limit, and no awareness of task context:
+`resolveDestinationThread` queries `messages_in ORDER BY seq DESC LIMIT 1` — it returns the most recent message regardless of age or kind. If a user message arrives on topic 51 before the task fires, the agent's reply routes to topic 51 instead of the intended destination.
 
-```sql
-SELECT thread_id, id FROM messages_in
-WHERE channel_type = ? AND platform_id = ?
-ORDER BY seq DESC LIMIT 1
-```
+### Fix: `thread_id` on task `messages_in`
 
-It returns the **most recent message regardless of how old it is**. If no user message arrives between two daily weather tasks, the routing is whatever the last user touched — which could be any topic.
+The fix writes the correct `thread_id` onto the task message itself at schedule time. When `resolveDestinationThread` queries the latest `messages_in`, it finds the task message with the correct topic. No changes to `resolveDestinationThread` or `sendToDestination` — the routing info travels with the message.
 
-### Why `session_routing` doesn't help
+**Flow:**
+1. Agent calls `schedule_task` with optional `threadId` parameter (e.g. `"telegram:<chatId>:<topicId>"`)
+2. Container writes the `threadId` into the system action payload
+3. Host's `handleScheduleTask` writes `thread_id` onto the task's `messages_in` row
+4. Task wakes the container → agent processes → dispatches reply
+5. `resolveDestinationThread` finds the task message (latest in the batch) with correct `thread_id`
+6. Recurring tasks inherit `thread_id` via `insertRecurrence` — one fix propagates to all future occurrences
 
-We intentionally removed per-message `upsertSessionRouting` because it made `session_routing` "last writer wins" — scheduled tasks inherited the last active topic instead of their intended one. The `session_routing` table is written only on container wake and stays stable for user-initiated conversations. But it doesn't carry topic-level routing information for tasks.
+**Admin config:** `ncl destinations update --agent-group-id <id> --local-name <name> --thread-id "telegram:<chatId>:<topicId>"` sets the thread on a destination. The agent can then use this value when calling `schedule_task`.
 
-### Possible fixes
+**Backward compat:** The `threadId` parameter on `schedule_task` is optional. When omitted, the existing behavior applies (reads from `session_routing.thread_id`). Existing tasks keep working until explicitly updated via `update_task --thread-id "..."`.
 
-| Option | Mechanism | Pros | Cons |
-|--------|-----------|------|------|
-| **1. Thread_id on task `messages_in`** | Scheduler writes `thread_id` to the task message | Clean — the task itself carries routing info | Requires scheduler to know which topic to target; needs a config field (`scheduled_thread_id` on messaging group or task) |
-| **2. `session_routing` fallback for tasks** | When `resolveDestinationThread` returns `null`, fall back to `session_routing.thread_id` | Uses existing infrastructure | Reintroduces the "last writer wins" problem for tasks specifically |
-| **3. `default_thread_id` on `agent_destinations`** | Each destination gets a thread_id hint; task dispatch uses it instead of resolving from `messages_in` | Separates config from runtime routing; destination-level granularity | Requires changes to destinations model and dispatch logic; needs `ncl destinations add --thread-id` support |
+### Design decisions
 
-Option 3 is the most architecturally clean — it separates "where should scheduled output go?" (a config concern) from "where was the last user message from?" (a routing concern). But it requires changes to the destinations model that touch both host and container code.
+**Why not override `sendToDestination`?** If `dest.threadId` always wins in `sendToDestination`, reply routing breaks — user messages from topic 42 would get redirected to the configured default topic. If `dest.threadId` is a fallback (only when `resolveDestinationThread` returns null), it doesn't fix the problem because `resolveDestinationThread` almost always returns a non-null topic from the latest user message.
+
+**Why not `session_routing` fallback?** We intentionally removed per-message `upsertSessionRouting` to prevent "last writer wins" pollution. `session_routing` is stable for user conversations but doesn't carry per-topic routing for tasks.
+
+**`send_message` MCP tool (Path B) already respects `dest.threadId`** — it prefers the destination's thread over the session's thread. This is correct for explicit mid-response sends. The fix here covers the `<message>` tag path (Path A), where the agent's response is parsed after the provider returns.
 
 ### Related
 

--- a/src/cli/resources/destinations.ts
+++ b/src/cli/resources/destinations.ts
@@ -87,5 +87,28 @@ registerResource({
         return { removed: { agent_group_id: agentGroupId, local_name: localName } };
       },
     },
+    update: {
+      access: 'approval',
+      description: 'Update a destination. Use --agent-group-id, --local-name, and fields to update (--thread-id).',
+      handler: async (args) => {
+        const agentGroupId = args.agent_group_id as string;
+        const localName = args.local_name as string;
+        if (!agentGroupId) throw new Error('--agent-group-id is required');
+        if (!localName) throw new Error('--local-name is required');
+        const sets: string[] = [];
+        const params: unknown[] = [];
+        if ('thread_id' in args) {
+          sets.push('thread_id = ?');
+          params.push((args.thread_id as string) ?? null);
+        }
+        if (sets.length === 0) throw new Error('no fields to update — pass --thread-id');
+        params.push(agentGroupId, localName);
+        const result = getDb()
+          .prepare(`UPDATE agent_destinations SET ${sets.join(', ')} WHERE agent_group_id = ? AND local_name = ?`)
+          .run(...params);
+        if (result.changes === 0) throw new Error('destination not found');
+        return { updated: { agent_group_id: agentGroupId, local_name: localName, fields: Object.fromEntries(sets.map((s) => [s.split(' = ')[0], params[sets.indexOf(s)]])) } };
+      },
+    },
   },
 });

--- a/src/modules/agent-to-agent/db/agent-destinations.ts
+++ b/src/modules/agent-to-agent/db/agent-destinations.ts
@@ -44,8 +44,8 @@ import { getDb } from '../../../db/connection.js';
 export function createDestination(row: AgentDestination): void {
   getDb()
     .prepare(
-      `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at)
-       VALUES (@agent_group_id, @local_name, @target_type, @target_id, @created_at)`,
+      `INSERT INTO agent_destinations (agent_group_id, local_name, target_type, target_id, created_at, thread_id)
+       VALUES (@agent_group_id, @local_name, @target_type, @target_id, @created_at, @thread_id)`,
     )
     .run(row);
 }
@@ -79,6 +79,32 @@ export function hasDestination(agentGroupId: string, targetType: 'channel' | 'ag
     .prepare('SELECT 1 FROM agent_destinations WHERE agent_group_id = ? AND target_type = ? AND target_id = ? LIMIT 1')
     .get(agentGroupId, targetType, targetId);
   return !!row;
+}
+
+/**
+ * Update mutable fields on an existing destination row.
+ * Currently only `thread_id` is mutable; pass undefined to leave unchanged.
+ *
+ * ⚠️  Caller responsibility: after this returns, call
+ * `writeDestinations(agentGroupId, <sessionId>)` for each active session
+ * so the update propagates to the running container's inbound.db.
+ */
+export function updateDestination(
+  agentGroupId: string,
+  localName: string,
+  updates: { thread_id?: string | null },
+): void {
+  const sets: string[] = [];
+  const params: unknown[] = [];
+  if ('thread_id' in updates) {
+    sets.push('thread_id = ?');
+    params.push(updates.thread_id);
+  }
+  if (sets.length === 0) return;
+  params.push(agentGroupId, localName);
+  getDb()
+    .prepare(`UPDATE agent_destinations SET ${sets.join(', ')} WHERE agent_group_id = ? AND local_name = ?`)
+    .run(...params);
 }
 
 /**

--- a/src/modules/scheduling/actions.ts
+++ b/src/modules/scheduling/actions.ts
@@ -84,6 +84,9 @@ export async function handleUpdateTask(
   if (content.script === null || typeof content.script === 'string') {
     update.script = content.script as string | null;
   }
+  if (content.threadId === null || typeof content.threadId === 'string') {
+    update.threadId = content.threadId as string | null;
+  }
   const touched = updateTask(inDb, taskId, update);
   log.info('Task updated', { taskId, touched, fields: Object.keys(update) });
   if (touched === 0) {

--- a/src/modules/scheduling/db.test.ts
+++ b/src/modules/scheduling/db.test.ts
@@ -252,6 +252,77 @@ describe('updateTask', () => {
     const touched = updateTask(db, 'task-1', { prompt: 'new' });
     expect(touched).toBe(0);
   });
+
+  it('updates thread_id when supplied', () => {
+    const db = freshDb();
+    insertTask(db, {
+      id: 'task-1',
+      processAfter: new Date().toISOString(),
+      recurrence: null,
+      platformId: null,
+      channelType: null,
+      threadId: null,
+      content: JSON.stringify({ prompt: 'p' }),
+    });
+
+    updateTask(db, 'task-1', { threadId: ':51' });
+
+    const row = db.prepare('SELECT thread_id FROM messages_in WHERE id = ?').get('task-1') as { thread_id: string | null };
+    expect(row.thread_id).toBe(':51');
+    db.close();
+  });
+
+  it('clears thread_id when null is passed', () => {
+    const db = freshDb();
+    insertTask(db, {
+      id: 'task-1',
+      processAfter: new Date().toISOString(),
+      recurrence: null,
+      platformId: null,
+      channelType: null,
+      threadId: ':99',
+      content: JSON.stringify({ prompt: 'p' }),
+    });
+
+    updateTask(db, 'task-1', { threadId: null });
+
+    const row = db.prepare('SELECT thread_id FROM messages_in WHERE id = ?').get('task-1') as { thread_id: string | null };
+    expect(row.thread_id).toBeNull();
+    db.close();
+  });
+
+  it('updates thread_id on live follow-up via series_id', () => {
+    const db = freshDb();
+    insertTask(db, {
+      id: 'task-orig',
+      processAfter: new Date().toISOString(),
+      recurrence: '0 9 * * *',
+      platformId: null,
+      channelType: null,
+      threadId: null,
+      content: JSON.stringify({ prompt: 'old' }),
+    });
+    db.prepare("UPDATE messages_in SET status = 'completed' WHERE id = 'task-orig'").run();
+
+    const msg: RecurringMessage = {
+      id: 'task-orig',
+      kind: 'task',
+      content: JSON.stringify({ prompt: 'old' }),
+      recurrence: '0 9 * * *',
+      process_after: null,
+      platform_id: null,
+      channel_type: null,
+      thread_id: null,
+      series_id: 'task-orig',
+    };
+    insertRecurrence(db, msg, 'task-next', new Date(Date.now() + 86400000).toISOString());
+
+    updateTask(db, 'task-orig', { threadId: ':42' });
+
+    const live = db.prepare("SELECT thread_id FROM messages_in WHERE id = 'task-next'").get() as { thread_id: string | null };
+    expect(live.thread_id).toBe(':42');
+    db.close();
+  });
 });
 
 describe('insertRecurrence', () => {
@@ -277,6 +348,39 @@ describe('insertRecurrence', () => {
       series_id: string;
     };
     expect(row.series_id).toBe('task-orig');
+    db.close();
+  });
+
+  it('copies thread_id forward', () => {
+    const db = freshDb();
+    insertTask(db, {
+      id: 'task-orig',
+      processAfter: new Date().toISOString(),
+      recurrence: '0 9 * * *',
+      platformId: null,
+      channelType: null,
+      threadId: ':51',
+      content: JSON.stringify({ prompt: 'weather' }),
+    });
+    db.prepare("UPDATE messages_in SET status = 'completed' WHERE id = 'task-orig'").run();
+
+    const msg: RecurringMessage = {
+      id: 'task-orig',
+      kind: 'task',
+      content: JSON.stringify({ prompt: 'weather' }),
+      recurrence: '0 9 * * *',
+      process_after: null,
+      platform_id: null,
+      channel_type: null,
+      thread_id: ':51',
+      series_id: 'task-orig',
+    };
+    insertRecurrence(db, msg, 'task-next', new Date().toISOString());
+
+    const row = db.prepare('SELECT thread_id FROM messages_in WHERE id = ?').get('task-next') as {
+      thread_id: string | null;
+    };
+    expect(row.thread_id).toBe(':51');
     db.close();
   });
 });

--- a/src/modules/scheduling/db.ts
+++ b/src/modules/scheduling/db.ts
@@ -58,6 +58,7 @@ export interface TaskUpdate {
   script?: string | null;
   recurrence?: string | null;
   processAfter?: string;
+  threadId?: string | null;
 }
 
 // Merges content JSON in-place so callers can update prompt/script without
@@ -75,6 +76,7 @@ export function updateTask(db: Database.Database, taskId: string, update: TaskUp
 
   const setProcessAfter = update.processAfter !== undefined;
   const setRecurrence = update.recurrence !== undefined;
+  const setThreadId = update.threadId !== undefined;
   const mergeContent = update.prompt !== undefined || update.script !== undefined;
 
   const tx = db.transaction(() => {
@@ -97,6 +99,10 @@ export function updateTask(db: Database.Database, taskId: string, update: TaskUp
       if (setRecurrence) {
         sets.push('recurrence = ?');
         params.push(update.recurrence);
+      }
+      if (setThreadId) {
+        sets.push('thread_id = ?');
+        params.push(update.threadId);
       }
       params.push(row.id);
 


### PR DESCRIPTION
## Problem

Scheduled tasks in shared-session Telegram groups had non-deterministic routing. The task output went to whatever topic had the last user message instead of a configured destination.

`resolveDestinationThread` queries `messages_in ORDER BY seq DESC LIMIT 1` — it returns the most recent message regardless of kind. A task message with `thread_id = null` followed by `resolveDestinationThread` picking up a user message from a different topic = wrong destination.

## Fix

Add optional `threadId` parameter to `schedule_task` and `update_task` MCP tools. When provided, the `thread_id` is written onto the task's `messages_in` row at schedule time, so `resolveDestinationThread` returns the correct topic when the agent dispatches the response.

No changes to `resolveDestinationThread` or `sendToDestination` — the routing info travels with the message.

### Changes

| File | Change |
|------|--------|
| `container/agent-runner/src/mcp-tools/scheduling.ts` | `schedule_task` gets `threadId` param; `update_task` gets `threadId` support |
| `src/modules/scheduling/db.ts` | `TaskUpdate` + `updateTask` SQL builder support `threadId` |
| `src/modules/scheduling/actions.ts` | `handleUpdateTask` passes `threadId` through |
| `src/modules/agent-to-agent/db/agent-destinations.ts` | `createDestination` includes `thread_id` in INSERT; new `updateDestination()` |
| `src/cli/resources/destinations.ts` | New `update` operation with `--thread-id` |
| `docs/telegram-topic-routing.md` | Document the fix and design decisions |

### Backward compat

`threadId` is optional on `schedule_task`. When omitted, existing behavior applies (`session_routing.thread_id`). Existing tasks keep working until updated via `update_task --thread-id "..."`. Recurring tasks inherit `thread_id` via `insertRecurrence`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)