### PR TITLE
feat(skills): add tg-logs skill for reading ingested topic messages

### DIFF
--- a/container/skills/tg-logs/SKILL.md
+++ b/container/skills/tg-logs/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: tg-logs
+description: Reads Telegram topic messages ingested by tg-topic-ingest from the mounted logs.db. Use when asked for a daily digest or summary of a topic's messages, or to look up recent entries by day.
+---
+
+# tg-logs Skill
+
+Reads messages from the host-mounted `logs.db` (read-only, at
+`/workspace/extra/logs.db`) and prints them for summarization or lookup. The DB
+is populated by the `tg-topic-ingest` service (Telegram forum topic → SQLite),
+one row per message, with a `source` column identifying the originating topic /
+config source.
+
+## Agent Execution
+
+```bash
+# Yesterday's entries as JSON (default — summarize this)
+bun run /app/skills/tg-logs/src/cli.ts
+
+# Human-readable
+bun run /app/skills/tg-logs/src/cli.ts --format text
+
+# A different day (N days ago; 0 = today)
+bun run /app/skills/tg-logs/src/cli.ts --days-ago 2
+
+# Limit to one source (as named in the ingest config)
+bun run /app/skills/tg-logs/src/cli.ts --source <source-name>
+```
+
+## Output
+
+JSON: `{ date, window:{start,end}, count, sources:[...], messages:[{msg_id, source, sender_name, date, text}] }`.
+
+- `date` / `window` are ISO-8601 UTC (`+00:00`), matching how `tg-topic-ingest` stores them.
+- `sender_name` is the Telegram display name.
+- The window is midnight-to-midnight **Asia/Hong_Kong**, converted to UTC.
+
+## Notes
+
+- Read-only: never writes to the DB.
+- If it errors "cannot open /workspace/extra/logs.db", the additional mount
+  isn't present — check the group's `additionalMounts` and the mount allowlist.

--- a/container/skills/tg-logs/src/cli.ts
+++ b/container/skills/tg-logs/src/cli.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env bun
+/**
+ * tg-logs skill — reads messages ingested by tg-topic-ingest from the mounted
+ * logs.db for a given HKT day and prints them for summarization or lookup.
+ *
+ * Usage:
+ *   bun run /app/skills/tg-logs/src/cli.ts                    # yesterday, all sources, JSON
+ *   bun run /app/skills/tg-logs/src/cli.ts --format text      # human-readable
+ *   bun run /app/skills/tg-logs/src/cli.ts --days-ago 2       # 2 days ago
+ *   bun run /app/skills/tg-logs/src/cli.ts --source <name>    # one source only
+ *
+ * Override the DB path for host-side testing: TG_LOGS_DB=./data/logs.db
+ */
+import { Database } from "bun:sqlite";
+
+const DB_PATH = process.env.TG_LOGS_DB ?? "/workspace/extra/logs.db";
+const HKT = "Asia/Hong_Kong";
+const HKT_OFFSET_MS = 8 * 3600 * 1000;
+const DAY_MS = 86400000;
+
+interface Args {
+  daysAgo: number;
+  format: "json" | "text";
+  source: string | null;
+}
+
+interface Row {
+  msg_id: number;
+  source: string;
+  sender_name: string | null;
+  date: string;
+  text: string | null;
+}
+
+function parseArgs(argv: string[]): Args {
+  const a: Args = { daysAgo: 1, format: "json", source: null };
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    const next = argv[i + 1];
+    if (flag === "--days-ago") (a.daysAgo = Number(next ?? 1)), i++;
+    else if (flag === "--format") (a.format = next === "text" ? "text" : "json"), i++;
+    else if (flag === "--source") (a.source = next ?? null), i++;
+    else if (flag === "-h" || flag === "--help") {
+      console.log("usage: tg-logs [--days-ago N] [--format json|text] [--source NAME]");
+      process.exit(0);
+    }
+  }
+  return a;
+}
+
+/** The HKT day `daysAgo` ago, midnight-to-midnight, as UTC ISO strings (+00:00, matching storage). */
+function windowFor(daysAgo: number): { start: string; end: string; label: string } {
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone: HKT, year: "numeric", month: "2-digit", day: "2-digit",
+  });
+  const [y, m, d] = fmt.format(new Date()).split("-").map(Number);
+  const todayMidHktUtcMs = Date.UTC(y, m - 1, d, 0, 0, 0) - HKT_OFFSET_MS; // HKT 00:00 == UTC−8h
+  const startMs = todayMidHktUtcMs - daysAgo * DAY_MS;
+  const endMs = todayMidHktUtcMs - (daysAgo - 1) * DAY_MS;
+  const iso = (ms: number) => new Date(ms).toISOString().replace(/\.\d{3}Z$/, "+00:00");
+  return { start: iso(startMs), end: iso(endMs), label: fmt.format(new Date(startMs)) };
+}
+
+const args = parseArgs(process.argv.slice(2));
+
+let db: Database;
+try {
+  db = new Database(DB_PATH, { readonly: true });
+} catch (e) {
+  console.error(`tg-logs: cannot open ${DB_PATH} (is the additional mount present?): ${e}`);
+  process.exit(1);
+}
+
+const { start, end, label } = windowFor(args.daysAgo);
+const rows: Row[] = args.source
+  ? db
+      .prepare(
+        `SELECT msg_id, source, sender_name, date, text
+           FROM messages
+          WHERE date >= ? AND date < ? AND source = ?
+          ORDER BY date`,
+      )
+      .all(start, end, args.source)
+  : db
+      .prepare(
+        `SELECT msg_id, source, sender_name, date, text
+           FROM messages
+          WHERE date >= ? AND date < ?
+          ORDER BY date`,
+      )
+      .all(start, end);
+db.close();
+
+const sources = [...new Set(rows.map((r) => r.source))].sort();
+
+if (args.format === "json") {
+  console.log(
+    JSON.stringify(
+      { date: label, window: { start, end }, count: rows.length, sources, messages: rows },
+      null,
+      2,
+    ),
+  );
+} else {
+  const srcs = sources.length ? ` — sources: ${sources.join(", ")}` : "";
+  console.log(`tg-logs — ${label} — ${rows.length} messages (${start} → ${end})${srcs}`);
+  for (const r of rows) {
+    const time = String(r.date).slice(11, 16);
+    const who = (r.sender_name ?? "?").padEnd(8);
+    const text = (r.text ?? "").replace(/\n/g, " / ");
+    console.log(`  ${time}  ${who}  ${text}`);
+  }
+}


### PR DESCRIPTION
## What
Adds a new read-only container skill `tg-logs` that queries the externally-mounted `logs.db` for a given HKT day's messages (optionally filtered by source) and prints them for the agent to summarize or look up.

## Why
Generic read side for data produced by the separate host service `tg-topic-ingest` (a Pyrogram MTProto ingestor that writes Telegram forum-topic messages into SQLite). This skill turns that DB into structured rows an agent can summarize (e.g. a daily digest) or query by day.

## How it works
- Opens `/workspace/extra/logs.db` **read-only** via `bun:sqlite` (zero deps — Bun ships it).
- Computes the requested HKT day (default: yesterday) as midnight-to-midnight, converted to UTC ISO (`+00:00`) to match how the ingest stores `date`.
- Optional `--source NAME` filters to one ingest source; default returns all.
- Query: `SELECT msg_id, source, sender_name, date, text FROM messages WHERE date >= ? AND date < ? [AND source = ?] ORDER BY date`.
- Output: JSON `{date, window, count, sources[], messages[]}` or chronological text (`--format text`); `--days-ago N` to pick the day.
- `TG_LOGS_DB` env override for host-side testing (in-container default is `/workspace/extra/logs.db`).

Knowledge + Bun-CLI skill → **no image rebuild**; synced into `~/.claude/skills/` at next spawn (groups with `skills: "all"` pick it up automatically).

## Requirements (deployment-side, not in this PR)
- The group's `additionalMounts` must expose `logs.db` (e.g. `{hostPath:".../data/logs.db", containerPath:"logs.db"}` → `/workspace/extra/logs.db`), with an entry in `mount-allowlist.json`.
- Source DB must use `journal_mode=DELETE` — WAL's `-shm` doesn't refresh across Docker bind mounts (see `docs/telegram-topic-routing.md`).

## Verification
Host-tested: `bun:sqlite` returns correct rows for yesterday's window; `--source` filter and missing-source (0 rows) cases verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)